### PR TITLE
test: add vitest coverage for components

### DIFF
--- a/src/components/block-list/card.spec.ts
+++ b/src/components/block-list/card.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { describe, beforeEach, it, expect } from 'vitest';
+
+import Card from './card';
+
+const mockBlock = {
+  id: '1',
+  title: 'Test Block',
+  description: 'Block description',
+  previewUrl: 'image.png',
+};
+
+describe('Card', () => {
+  let fixture: ComponentFixture<Card>;
+  let component: Card;
+
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [Card, RouterTestingModule, NoopAnimationsModule],
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(Card);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('block', mockBlock);
+    fixture.componentRef.setInput('path', 'section');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render block data', () => {
+    const compiled: HTMLElement = fixture.nativeElement;
+    const title = compiled.querySelector('h3');
+    const img = compiled.querySelector('img');
+    expect(title?.textContent).toContain(mockBlock.title);
+    expect(img?.getAttribute('src')).toBe(mockBlock.previewUrl);
+    expect(img?.getAttribute('alt')).toBe(mockBlock.title);
+  });
+});

--- a/src/components/footer.spec.ts
+++ b/src/components/footer.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { expect, describe, beforeEach, it } from 'vitest';
+
+import Footer from './footer';
+
+
+describe('Footer', () => {
+  let fixture: ComponentFixture<Footer>;
+  let component: Footer;
+
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [Footer, RouterTestingModule, NoopAnimationsModule],
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(Footer);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render current year', () => {
+    const compiled: HTMLElement = fixture.nativeElement;
+    const year = new Date().getFullYear().toString();
+    expect(compiled.textContent).toContain(year);
+  });
+});

--- a/src/components/section-header.spec.ts
+++ b/src/components/section-header.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { expect, describe, beforeEach, it } from 'vitest';
+
+import SectionHeader from './section-header';
+
+
+describe('SectionHeader', () => {
+  let fixture: ComponentFixture<SectionHeader>;
+  let component: SectionHeader;
+
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [SectionHeader],
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SectionHeader);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('data', { title: 'Title', description: 'Desc' });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render provided title and description', () => {
+    const compiled: HTMLElement = fixture.nativeElement;
+    const titleEl = compiled.querySelector('h3');
+    const descEl = compiled.querySelector('p');
+    expect(titleEl?.textContent).toContain('Title');
+    expect(descEl?.textContent).toContain('Desc');
+  });
+});

--- a/src/components/section-navigation.spec.ts
+++ b/src/components/section-navigation.spec.ts
@@ -1,0 +1,40 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+
+import SectionNavigation from './section-navigation';
+
+
+describe('SectionNavigation', () => {
+  let fixture: ComponentFixture<SectionNavigation>;
+  let component: SectionNavigation;
+
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [SectionNavigation, RouterTestingModule, NoopAnimationsModule],
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SectionNavigation);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit navigation events', () => {
+    const spy = vi.fn();
+    component.navigationButton.subscribe(spy);
+    const buttons = fixture.nativeElement.querySelectorAll('button');
+    // index 1 -> prev, index 2 -> next
+    (buttons[1] as HTMLButtonElement).click();
+    (buttons[2] as HTMLButtonElement).click();
+    expect(spy).toHaveBeenCalledWith('prev');
+    expect(spy).toHaveBeenCalledWith('next');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for SectionHeader, SectionNavigation, Footer and Card components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689110ee53d4832090158bbe0a6a7777