### PR TITLE
feat: add footer example blocks

### DIFF
--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -29,7 +29,7 @@ const appConfig: ApplicationConfig = {
         css: () => import('highlight.js/lib/languages/css'),
         xml: () => import('highlight.js/lib/languages/xml'),
       },
-      themePath: 'styles/github-dark.css',
+      themePath: 'styles/github-dark.min.css',
     }),
   ],
 };

--- a/src/app/sections/block.ts
+++ b/src/app/sections/block.ts
@@ -8,6 +8,7 @@ import { pricingBlocksWithViews } from '@examples/pricing/data';
 import { teamBlocksWithViews } from '@examples/team/data';
 import { testimonialBlocksWithViews } from '@examples/testimonials/data';
 import { contactBlocksWithViews } from '@examples/contact/data';
+import { footerBlocksWithViews } from '@examples/footers/data';
 
 @Component({
   selector: 'page-block-details',
@@ -37,4 +38,5 @@ const sectionBlocks = {
     testimonials: testimonialBlocksWithViews,
     team: teamBlocksWithViews,
     contact: contactBlocksWithViews,
+    footers: footerBlocksWithViews,
   };

--- a/src/app/sections/footers/index.ts
+++ b/src/app/sections/footers/index.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import BlocksList from '@components/block-list';
+import { footerSectionData } from '@examples/footers/data';
+
+@Component({
+  selector: 'page-blocks-list',
+  imports: [BlocksList],
+  template: ` <blocks-list [data]="data" />`,
+})
+export default class FootersPage {
+  public data = footerSectionData;
+}

--- a/src/app/sections/footers/routes.ts
+++ b/src/app/sections/footers/routes.ts
@@ -1,0 +1,12 @@
+import { Routes } from '@angular/router';
+
+const route: Routes = [
+  { path: '', loadComponent: () => import('.') },
+  {
+    path: ':id',
+    loadComponent: () => import('../block'),
+    data: { path: 'footers' },
+  },
+];
+
+export default route;

--- a/src/app/sections/routes.ts
+++ b/src/app/sections/routes.ts
@@ -25,12 +25,16 @@ const sectionRoutes: Routes = [
           path: 'team',
           loadChildren: () => import('./team/routes'),
         },
-        {
-          path: 'contact',
-          loadChildren: () => import('./contact/routes'),
-        },
-      ],
-    },
-  ];
+      {
+        path: 'contact',
+        loadChildren: () => import('./contact/routes'),
+      },
+      {
+        path: 'footers',
+        loadChildren: () => import('./footers/routes'),
+      },
+    ],
+  },
+];
 
 export default sectionRoutes;

--- a/src/components/home/hero.ts
+++ b/src/components/home/hero.ts
@@ -16,7 +16,7 @@ import { RouterModule } from '@angular/router';
           >
             Copy-Paste Ready
             <span
-              class="block text-transparent bg-clip-text bg-gradient-to-r from-foreground/50 to-foreground"
+              class="min-h-20 block text-transparent bg-clip-text bg-gradient-to-r from-foreground/50 to-foreground"
             >
               Angular Blocks
             </span>

--- a/src/examples/footers/data.ts
+++ b/src/examples/footers/data.ts
@@ -1,0 +1,167 @@
+import { BlockCard, SectionData, BlockData } from '@shared/interfaces';
+
+export const footerBlocks: BlockCard[] = [
+  {
+    id: '1',
+    title: 'Simple Footer',
+    description: 'Centered text and icons for basic projects',
+    previewUrl: 'https://placehold.co/600x400?text=Simple+Footer',
+    iframeUrl: '/examples/footer/1',
+  },
+  {
+    id: '2',
+    title: 'Links Footer',
+    description: 'Three-column layout with navigation links',
+    previewUrl: 'https://placehold.co/600x400?text=Links+Footer',
+    iframeUrl: '/examples/footer/2',
+  },
+  {
+    id: '3',
+    title: 'Newsletter Footer',
+    description: 'Footer with email subscription form',
+    previewUrl: 'https://placehold.co/600x400?text=Newsletter+Footer',
+    iframeUrl: '/examples/footer/3',
+  },
+  {
+    id: '4',
+    title: 'Navigation Footer',
+    description: 'Footer with logo and navigation menu',
+    previewUrl: 'https://placehold.co/600x400?text=Navigation+Footer',
+    iframeUrl: '/examples/footer/4',
+  },
+];
+
+export const footerSectionData: SectionData = {
+  title: 'UI Footer Collection',
+  description: 'Website footers with links, forms and social icons.',
+  path: 'footers',
+  blocks: [...footerBlocks],
+};
+
+export const footerBlocksWithViews: BlockData[] = footerBlocks.map((block) => {
+  const codeTemplates: any = {
+    '1': {
+      template: `<footer class="py-8 bg-gray-100 dark:bg-gray-900">
+  <div class="container mx-auto text-center space-y-4">
+    <div class="flex justify-center gap-6">
+      <mat-icon>home</mat-icon>
+      <mat-icon>mail</mat-icon>
+      <mat-icon>favorite</mat-icon>
+    </div>
+    <p class="text-sm text-gray-600 dark:text-gray-400">&copy; 2024 Acme Inc.</p>
+  </div>
+</footer>`,
+      component: `import { Component } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-footer-simple',
+  standalone: true,
+  imports: [MatIcon],
+  templateUrl: './footer-simple.component.html',
+})
+export class FooterSimpleComponent {}`,
+      styles: ``,
+    },
+    '2': {
+      template: `<footer class="py-10 bg-gray-800 text-gray-300">
+  <div class="container mx-auto px-4 grid sm:grid-cols-3 gap-8">
+    <div>
+      <h3 class="font-semibold mb-4">Company</h3>
+      <ul class="space-y-2">
+        <li><a href="#">About</a></li>
+        <li><a href="#">Careers</a></li>
+        <li><a href="#">Blog</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-semibold mb-4">Support</h3>
+      <ul class="space-y-2">
+        <li><a href="#">Help Center</a></li>
+        <li><a href="#">Terms of Service</a></li>
+        <li><a href="#">Privacy Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-semibold mb-4">Contact</h3>
+      <ul class="space-y-2">
+        <li><a href="#">Email</a></li>
+        <li><a href="#">Twitter</a></li>
+        <li><a href="#">LinkedIn</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="mt-8 text-center text-sm text-gray-500">&copy; 2024 Acme Inc.</div>
+</footer>`,
+      component: `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer-links',
+  standalone: true,
+  templateUrl: './footer-links.component.html',
+})
+export class FooterLinksComponent {}`,
+      styles: ``,
+    },
+    '3': {
+      template: `<footer class="py-16 bg-gray-100 dark:bg-gray-800">
+  <div class="container mx-auto text-center">
+    <h2 class="text-2xl font-bold mb-4">Stay in touch</h2>
+    <p class="text-gray-600 mb-6">Join our newsletter</p>
+    <form class="max-w-md mx-auto flex gap-2">
+      <mat-form-field appearance="outline" class="flex-1">
+        <mat-label>Email</mat-label>
+        <input matInput type="email" />
+      </mat-form-field>
+      <button mat-raised-button color="primary">Subscribe</button>
+    </form>
+    <p class="mt-8 text-sm text-gray-500">&copy; 2024 Acme Inc.</p>
+  </div>
+</footer>`,
+      component: `import { Component } from '@angular/core';
+import { MatFormField } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatButton } from '@angular/material/button';
+
+@Component({
+  selector: 'app-footer-newsletter',
+  standalone: true,
+  imports: [MatFormField, MatInput, MatButton],
+  templateUrl: './footer-newsletter.component.html',
+})
+export class FooterNewsletterComponent {}`,
+      styles: ``,
+    },
+    '4': {
+      template: `<footer class="py-10 bg-gray-900 text-gray-300">
+  <div class="container mx-auto px-4 flex flex-col md:flex-row items-center justify-between gap-6">
+    <div class="text-lg font-bold">Acme</div>
+    <nav class="flex gap-6">
+      <a href="#" class="hover:text-white">Home</a>
+      <a href="#" class="hover:text-white">Features</a>
+      <a href="#" class="hover:text-white">Contact</a>
+    </nav>
+    <div class="text-sm">&copy; 2024 Acme Inc.</div>
+  </div>
+</footer>`,
+      component: `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer-nav',
+  standalone: true,
+  templateUrl: './footer-nav.component.html',
+})
+export class FooterNavComponent {}`,
+      styles: ``,
+    },
+  };
+
+  return {
+    ...block,
+    views: [
+      { label: 'Template', content: codeTemplates[block.id].template, language: 'html' },
+      { label: 'Component', content: codeTemplates[block.id].component, language: 'typescript' },
+      { label: 'Styles', content: codeTemplates[block.id].styles, language: 'css' },
+    ],
+  };
+});

--- a/src/examples/footers/footer-1.ts
+++ b/src/examples/footers/footer-1.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+
+@Component({
+  selector: 'example-footer-1',
+  imports: [MatIcon],
+  template: `<footer class="py-8 bg-gray-100 dark:bg-gray-900">
+  <div class="container mx-auto text-center space-y-4">
+    <div class="flex justify-center gap-6">
+      <mat-icon>home</mat-icon>
+      <mat-icon>mail</mat-icon>
+      <mat-icon>favorite</mat-icon>
+    </div>
+    <p class="text-sm text-gray-600 dark:text-gray-400">&copy; 2024 Acme Inc.</p>
+  </div>
+</footer>`,
+})
+export default class Footer1 {}

--- a/src/examples/footers/footer-2.ts
+++ b/src/examples/footers/footer-2.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'example-footer-2',
+  template: `<footer class="py-10 bg-gray-800 text-gray-300">
+  <div class="container mx-auto px-4 grid sm:grid-cols-3 gap-8">
+    <div>
+      <h3 class="font-semibold mb-4">Company</h3>
+      <ul class="space-y-2">
+        <li><a href="#">About</a></li>
+        <li><a href="#">Careers</a></li>
+        <li><a href="#">Blog</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-semibold mb-4">Support</h3>
+      <ul class="space-y-2">
+        <li><a href="#">Help Center</a></li>
+        <li><a href="#">Terms of Service</a></li>
+        <li><a href="#">Privacy Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3 class="font-semibold mb-4">Contact</h3>
+      <ul class="space-y-2">
+        <li><a href="#">Email</a></li>
+        <li><a href="#">Twitter</a></li>
+        <li><a href="#">LinkedIn</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="mt-8 text-center text-sm text-gray-500">&copy; 2024 Acme Inc.</div>
+</footer>`,
+})
+export default class Footer2 {}

--- a/src/examples/footers/footer-3.ts
+++ b/src/examples/footers/footer-3.ts
@@ -1,24 +1,24 @@
 import { Component } from '@angular/core';
-import { MatFormField } from '@angular/material/form-field';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatButton } from '@angular/material/button';
 
 @Component({
   selector: 'example-footer-3',
-  imports: [MatFormField, MatInput, MatButton],
+  imports: [MatFormField, MatInput, MatButton, MatLabel],
   template: `<footer class="py-16 bg-gray-100 dark:bg-gray-800">
-  <div class="container mx-auto text-center">
-    <h2 class="text-2xl font-bold mb-4">Stay in touch</h2>
-    <p class="text-gray-600 mb-6">Join our newsletter</p>
-    <form class="max-w-md mx-auto flex gap-2">
-      <mat-form-field appearance="outline" class="flex-1">
-        <mat-label>Email</mat-label>
-        <input matInput type="email" />
-      </mat-form-field>
-      <button mat-raised-button color="primary">Subscribe</button>
-    </form>
-    <p class="mt-8 text-sm text-gray-500">&copy; 2024 Acme Inc.</p>
-  </div>
-</footer>`,
+    <div class="container mx-auto text-center">
+      <h2 class="text-2xl font-bold mb-4">Stay in touch</h2>
+      <p class="text-gray-600 mb-6">Join our newsletter</p>
+      <form class="max-w-md mx-auto flex gap-2">
+        <mat-form-field appearance="outline" class="flex-1">
+          <mat-label>Email</mat-label>
+          <input matInput type="email" />
+        </mat-form-field>
+        <button mat-raised-button color="primary">Subscribe</button>
+      </form>
+      <p class="mt-8 text-sm text-gray-500">&copy; 2024 Acme Inc.</p>
+    </div>
+  </footer>`,
 })
 export default class Footer3 {}

--- a/src/examples/footers/footer-3.ts
+++ b/src/examples/footers/footer-3.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { MatFormField } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatButton } from '@angular/material/button';
+
+@Component({
+  selector: 'example-footer-3',
+  imports: [MatFormField, MatInput, MatButton],
+  template: `<footer class="py-16 bg-gray-100 dark:bg-gray-800">
+  <div class="container mx-auto text-center">
+    <h2 class="text-2xl font-bold mb-4">Stay in touch</h2>
+    <p class="text-gray-600 mb-6">Join our newsletter</p>
+    <form class="max-w-md mx-auto flex gap-2">
+      <mat-form-field appearance="outline" class="flex-1">
+        <mat-label>Email</mat-label>
+        <input matInput type="email" />
+      </mat-form-field>
+      <button mat-raised-button color="primary">Subscribe</button>
+    </form>
+    <p class="mt-8 text-sm text-gray-500">&copy; 2024 Acme Inc.</p>
+  </div>
+</footer>`,
+})
+export default class Footer3 {}

--- a/src/examples/footers/footer-4.ts
+++ b/src/examples/footers/footer-4.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'example-footer-4',
+  template: `<footer class="py-10 bg-gray-900 text-gray-300">
+  <div class="container mx-auto px-4 flex flex-col md:flex-row items-center justify-between gap-6">
+    <div class="text-lg font-bold">Acme</div>
+    <nav class="flex gap-6">
+      <a href="#" class="hover:text-white">Home</a>
+      <a href="#" class="hover:text-white">Features</a>
+      <a href="#" class="hover:text-white">Contact</a>
+    </nav>
+    <div class="text-sm">&copy; 2024 Acme Inc.</div>
+  </div>
+</footer>`,
+})
+export default class Footer4 {}

--- a/src/examples/footers/footer.routes.ts
+++ b/src/examples/footers/footer.routes.ts
@@ -1,0 +1,15 @@
+import { Routes } from '@angular/router';
+
+const footerRoutes: Routes = [
+  {
+    path: '',
+    children: [
+      { path: '1', loadComponent: () => import('@examples/footers/footer-1') },
+      { path: '2', loadComponent: () => import('@examples/footers/footer-2') },
+      { path: '3', loadComponent: () => import('@examples/footers/footer-3') },
+      { path: '4', loadComponent: () => import('@examples/footers/footer-4') },
+    ],
+  },
+];
+
+export default footerRoutes;

--- a/src/examples/routes.ts
+++ b/src/examples/routes.ts
@@ -25,6 +25,10 @@ const examplesRoutes: Routes = [
     path: 'contact',
     loadChildren: () => import('./contact/contact.routes'),
   },
+  {
+    path: 'footer',
+    loadChildren: () => import('./footers/footer.routes'),
+  },
 ];
 
 export default examplesRoutes;

--- a/src/server/routes.server.ts
+++ b/src/server/routes.server.ts
@@ -55,6 +55,14 @@ export const serverRoutes: ServerRoute[] = [
       return [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }];
     },
   },
+  {
+    path: 'sections/footers/:id',
+    renderMode: RenderMode.Prerender,
+    fallback: PrerenderFallback.Client,
+    async getPrerenderParams() {
+      return [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }];
+    },
+  },
 
   {
     path: '**',


### PR DESCRIPTION
## Summary
- add four footer example blocks with accompanying metadata
- wire up footer examples to section and example routes
- map footer block data for block detail pages

## Testing
- `npm test` *(fails: Highlight.js library was not imported)*

------
https://chatgpt.com/codex/tasks/task_e_6891f202a9108320898b801a4e1911a7