### PR TITLE
feat: add ecommerce example blocks

### DIFF
--- a/src/app/sections/block.ts
+++ b/src/app/sections/block.ts
@@ -9,6 +9,7 @@ import { teamBlocksWithViews } from '@examples/team/data';
 import { testimonialBlocksWithViews } from '@examples/testimonials/data';
 import { contactBlocksWithViews } from '@examples/contact/data';
 import { footerBlocksWithViews } from '@examples/footers/data';
+import { ecommerceBlocksWithViews } from '@examples/ecommerce/data';
 
 @Component({
   selector: 'page-block-details',
@@ -35,6 +36,7 @@ const sectionBlocks = {
   heroes: heroBlocksWithViews,
     features: featureBlocksWithViews,
     pricing: pricingBlocksWithViews,
+    ecommerce: ecommerceBlocksWithViews,
     testimonials: testimonialBlocksWithViews,
     team: teamBlocksWithViews,
     contact: contactBlocksWithViews,

--- a/src/app/sections/ecommerce/index.ts
+++ b/src/app/sections/ecommerce/index.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import BlocksList from '@components/block-list';
+import { ecommerceSectionsData } from '@examples/ecommerce/data';
+
+@Component({
+  selector: 'page-blocks-list',
+  imports: [BlocksList],
+  template: ` <blocks-list [data]="data" />`,
+})
+export default class EcommercePage {
+  public data = ecommerceSectionsData;
+}

--- a/src/app/sections/ecommerce/routes.ts
+++ b/src/app/sections/ecommerce/routes.ts
@@ -1,0 +1,12 @@
+import { Routes } from '@angular/router';
+
+const route: Routes = [
+  { path: '', loadComponent: () => import('.') },
+  {
+    path: ':id',
+    loadComponent: () => import('../block'),
+    data: { path: 'ecommerce' },
+  },
+];
+
+export default route;

--- a/src/app/sections/routes.ts
+++ b/src/app/sections/routes.ts
@@ -18,6 +18,10 @@ const sectionRoutes: Routes = [
         loadChildren: () => import('./pricing/routes'),
       },
       {
+        path: 'ecommerce',
+        loadChildren: () => import('./ecommerce/routes'),
+      },
+      {
         path: 'testimonials',
         loadChildren: () => import('./testimonials/routes'),
       },

--- a/src/examples/ecommerce/data.ts
+++ b/src/examples/ecommerce/data.ts
@@ -1,0 +1,72 @@
+import { type BlockData, type BlockCard } from '@shared/interfaces';
+
+export const ecommerceBlocks: BlockCard[] = [
+  {
+    id: '1',
+    title: 'Product Grid',
+    description: 'Responsive product card grid for storefronts',
+    previewUrl: 'https://placehold.co/600x400?text=Product+Grid',
+    iframeUrl: '/examples/ecommerce/1',
+  },
+  {
+    id: '2',
+    title: 'Product Showcase',
+    description: 'Featured product layout with actions',
+    previewUrl: 'https://placehold.co/600x400?text=Product+Showcase',
+    iframeUrl: '/examples/ecommerce/2',
+  },
+  {
+    id: '3',
+    title: 'Cart Summary',
+    description: 'Shopping cart summary with totals',
+    previewUrl: 'https://placehold.co/600x400?text=Cart+Summary',
+    iframeUrl: '/examples/ecommerce/3',
+  },
+  {
+    id: '4',
+    title: 'Checkout Summary',
+    description: 'Checkout form with order summary',
+    previewUrl: 'https://placehold.co/600x400?text=Checkout+Summary',
+    iframeUrl: '/examples/ecommerce/4',
+  },
+];
+
+export const ecommerceSectionsData = {
+  title: 'UI Ecommerce Collection',
+  description: 'Product displays, cart interfaces and checkout layouts.',
+  path: 'ecommerce',
+  blocks: [...ecommerceBlocks],
+};
+
+export const ecommerceBlocksWithViews: BlockData[] = ecommerceBlocks.map((block) => {
+  const codeTemplates: any = {
+    '1': {
+      template: '<example-ecommerce-1></example-ecommerce-1>',
+      component: '',
+      styles: '',
+    },
+    '2': {
+      template: '<example-ecommerce-2></example-ecommerce-2>',
+      component: '',
+      styles: '',
+    },
+    '3': {
+      template: '<example-ecommerce-3></example-ecommerce-3>',
+      component: '',
+      styles: '',
+    },
+    '4': {
+      template: '<example-ecommerce-4></example-ecommerce-4>',
+      component: '',
+      styles: '',
+    },
+  };
+  return {
+    ...block,
+    views: [
+      { label: 'Template', content: codeTemplates[block.id].template, language: 'html' },
+      { label: 'Component', content: codeTemplates[block.id].component, language: 'typescript' },
+      { label: 'Styles', content: codeTemplates[block.id].styles, language: 'css' },
+    ],
+  };
+});

--- a/src/examples/ecommerce/ecommerce-1.ts
+++ b/src/examples/ecommerce/ecommerce-1.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'example-ecommerce-1',
+  imports: [MatCardModule, MatButtonModule, MatIconModule],
+  template: `
+  <section class="py-20 px-4 bg-gray-50 dark:bg-gray-900">
+    <div class="max-w-6xl mx-auto grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+      @for (product of products; track $index) {
+        <mat-card class="p-4 flex flex-col animate-fade-in">
+          <img [src]="product.image" [alt]="product.name" class="h-48 w-full object-cover rounded mb-4" />
+          <h3 class="text-lg font-semibold mb-2">{{ product.name }}</h3>
+          <p class="text-gray-600 dark:text-gray-300 mb-4">{{ product.price }}</p>
+          <button mat-raised-button color="primary">Add to cart</button>
+        </mat-card>
+      }
+    </div>
+  </section>
+  `,
+})
+export default class Ecommerce1 {
+  products = [
+    { name: 'Product 1', price: '$29', image: 'https://placehold.co/400x300' },
+    { name: 'Product 2', price: '$49', image: 'https://placehold.co/400x300' },
+    { name: 'Product 3', price: '$19', image: 'https://placehold.co/400x300' },
+  ];
+}

--- a/src/examples/ecommerce/ecommerce-2.ts
+++ b/src/examples/ecommerce/ecommerce-2.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'example-ecommerce-2',
+  imports: [MatCardModule, MatButtonModule, MatIconModule],
+  template: `
+  <section class="py-20 px-4">
+    <div class="max-w-3xl mx-auto grid md:grid-cols-2 gap-8 items-center">
+      <img src="https://placehold.co/600x400" alt="Product" class="rounded-lg w-full h-auto" />
+      <div>
+        <h2 class="text-3xl font-bold mb-4">Premium Headphones</h2>
+        <p class="text-gray-600 dark:text-gray-300 mb-6">High-fidelity sound with noise cancellation.</p>
+        <div class="text-2xl font-bold mb-6">$199</div>
+        <button mat-raised-button color="primary" class="mr-2">Add to cart</button>
+        <button mat-stroked-button>Buy Now</button>
+      </div>
+    </div>
+  </section>
+  `,
+})
+export default class Ecommerce2 {}

--- a/src/examples/ecommerce/ecommerce-3.ts
+++ b/src/examples/ecommerce/ecommerce-3.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'example-ecommerce-3',
+  imports: [MatCardModule, MatButtonModule, MatIconModule],
+  template: `
+  <section class="py-20 px-4 bg-gray-50 dark:bg-gray-800">
+    <div class="max-w-3xl mx-auto">
+      <h2 class="text-2xl font-bold mb-6">Shopping Cart</h2>
+      <div class="space-y-4">
+        @for (item of cart; track $index) {
+          <mat-card class="p-4 flex items-center justify-between">
+            <div class="flex items-center gap-4">
+              <img [src]="item.image" [alt]="item.name" class="w-16 h-16 rounded" />
+              <div>
+                <h3 class="font-medium">{{ item.name }}</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-300">Qty: {{ item.qty }}</p>
+              </div>
+            </div>
+            <div class="font-semibold">{{ item.price }}</div>
+          </mat-card>
+        }
+        <div class="text-right text-xl font-bold mt-6">Total: {{ total }}</div>
+        <button mat-raised-button color="primary" class="w-full mt-4">Checkout</button>
+      </div>
+    </div>
+  </section>
+  `,
+})
+export default class Ecommerce3 {
+  cart = [
+    { name: 'Product 1', qty: 1, price: '$29', image: 'https://placehold.co/100' },
+    { name: 'Product 2', qty: 2, price: '$49', image: 'https://placehold.co/100' },
+  ];
+  get total() {
+    return '$127';
+  }
+}

--- a/src/examples/ecommerce/ecommerce-4.ts
+++ b/src/examples/ecommerce/ecommerce-4.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+@Component({
+  selector: 'example-ecommerce-4',
+  imports: [
+    MatCardModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
+  template: `
+  <section class="py-20 px-4">
+    <div class="max-w-4xl mx-auto grid md:grid-cols-2 gap-8">
+      <form class="space-y-4">
+        <h2 class="text-2xl font-bold mb-4">Shipping Info</h2>
+        <mat-form-field appearance="fill" class="w-full">
+          <mat-label>Name</mat-label>
+          <input matInput />
+        </mat-form-field>
+        <mat-form-field appearance="fill" class="w-full">
+          <mat-label>Address</mat-label>
+          <input matInput />
+        </mat-form-field>
+        <mat-form-field appearance="fill" class="w-full">
+          <mat-label>City</mat-label>
+          <input matInput />
+        </mat-form-field>
+      </form>
+      <mat-card class="p-6">
+        <h2 class="text-2xl font-bold mb-4">Order Summary</h2>
+        <div class="flex justify-between mb-2">
+          <span>Subtotal</span>
+          <span>$127</span>
+        </div>
+        <div class="flex justify-between mb-4">
+          <span>Shipping</span>
+          <span>$10</span>
+        </div>
+        <div class="flex justify-between text-xl font-semibold mb-6">
+          <span>Total</span>
+          <span>$137</span>
+        </div>
+        <button mat-raised-button color="primary" class="w-full">Place Order</button>
+      </mat-card>
+    </div>
+  </section>
+  `,
+})
+export default class Ecommerce4 {}

--- a/src/examples/ecommerce/ecommerce.routes.ts
+++ b/src/examples/ecommerce/ecommerce.routes.ts
@@ -1,0 +1,15 @@
+import { Routes } from '@angular/router';
+
+const ecommerceRoutes: Routes = [
+  {
+    path: '',
+    children: [
+      { path: '1', loadComponent: () => import('@examples/ecommerce/ecommerce-1') },
+      { path: '2', loadComponent: () => import('@examples/ecommerce/ecommerce-2') },
+      { path: '3', loadComponent: () => import('@examples/ecommerce/ecommerce-3') },
+      { path: '4', loadComponent: () => import('@examples/ecommerce/ecommerce-4') },
+    ],
+  },
+];
+
+export default ecommerceRoutes;

--- a/src/examples/routes.ts
+++ b/src/examples/routes.ts
@@ -14,6 +14,10 @@ const examplesRoutes: Routes = [
     loadChildren: () => import('./pricing/pricing.routes'),
   },
   {
+    path: 'ecommerce',
+    loadChildren: () => import('./ecommerce/ecommerce.routes'),
+  },
+  {
     path: 'testimonials',
     loadChildren: () => import('./testimonials/testimonials.routes'),
   },


### PR DESCRIPTION
## Summary
- add four ecommerce example blocks: product grid, showcase, cart summary, checkout summary
- register ecommerce section and routes
- provide ecommerce block metadata for listings

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689201593ca0832089daa5612c4fcb91