### PR TITLE
feat(examples): add component source for remaining blocks

### DIFF
--- a/src/examples/blog/data.ts
+++ b/src/examples/blog/data.ts
@@ -1,4 +1,10 @@
-import { BlockCard, SectionData, BlockData } from '@shared/interfaces';
+import { type BlockData, type BlockCard, type SectionData } from '@shared/interfaces';
+import blog1 from './blog-1.ts?raw';
+import blog2 from './blog-2.ts?raw';
+import blog3 from './blog-3.ts?raw';
+import blog4 from './blog-4.ts?raw';
+
+const componentContent = [blog1, blog2, blog3, blog4];
 
 export const blogBlocks: BlockCard[] = [
   {
@@ -38,7 +44,7 @@ export const blogSectionData: SectionData = {
   blocks: [...blogBlocks],
 };
 
-export const blogBlocksWithViews: BlockData[] = blogBlocks.map((block) => {
+export const blogBlocksWithViews: BlockData[] = blogBlocks.map((block, index) => {
   const codeTemplates: any = {
     '1': {
       template: `<section class="py-24">
@@ -205,6 +211,7 @@ export class BlogSidebarComponent {}`,
 
   return {
     ...block,
+    content: componentContent[index],
     views: [
       {
         label: 'Template',

--- a/src/examples/contact/data.ts
+++ b/src/examples/contact/data.ts
@@ -1,4 +1,10 @@
-import { BlockCard, SectionData, BlockData } from '@shared/interfaces';
+import { type BlockData, type BlockCard, type SectionData } from '@shared/interfaces';
+import contact1 from './contact-1.ts?raw';
+import contact2 from './contact-2.ts?raw';
+import contact3 from './contact-3.ts?raw';
+import contact4 from './contact-4.ts?raw';
+
+const componentContent = [contact1, contact2, contact3, contact4];
 
 export const contactBlocks: BlockCard[] = [
   {
@@ -39,7 +45,7 @@ export const contactSectionData: SectionData = {
 };
 
 export const contactBlocksWithViews: BlockData[] = contactBlocks.map(
-  (block) => {
+  (block, index) => {
     const codeTemplates: any = {
       '1': {
         template: `<section class="py-24">
@@ -224,6 +230,7 @@ export class Contact4Component {}`,
 
     return {
       ...block,
+      content: componentContent[index],
       views: [
         {
           label: 'Template',

--- a/src/examples/ecommerce/data.ts
+++ b/src/examples/ecommerce/data.ts
@@ -1,4 +1,10 @@
 import { type BlockData, type BlockCard } from '@shared/interfaces';
+import ecommerce1 from './ecommerce-1.ts?raw';
+import ecommerce2 from './ecommerce-2.ts?raw';
+import ecommerce3 from './ecommerce-3.ts?raw';
+import ecommerce4 from './ecommerce-4.ts?raw';
+
+const componentContent = [ecommerce1, ecommerce2, ecommerce3, ecommerce4];
 
 export const ecommerceBlocks: BlockCard[] = [
   {
@@ -38,7 +44,7 @@ export const ecommerceSectionsData = {
   blocks: [...ecommerceBlocks],
 };
 
-export const ecommerceBlocksWithViews: BlockData[] = ecommerceBlocks.map((block) => {
+export const ecommerceBlocksWithViews: BlockData[] = ecommerceBlocks.map((block, index) => {
   const codeTemplates: any = {
     '1': {
       template: '<example-ecommerce-1></example-ecommerce-1>',
@@ -63,6 +69,7 @@ export const ecommerceBlocksWithViews: BlockData[] = ecommerceBlocks.map((block)
   };
   return {
     ...block,
+    content: componentContent[index],
     views: [
       { label: 'Template', content: codeTemplates[block.id].template, language: 'html' },
       { label: 'Component', content: codeTemplates[block.id].component, language: 'typescript' },

--- a/src/examples/features/data.ts
+++ b/src/examples/features/data.ts
@@ -1,5 +1,319 @@
-import { BlockCard, SectionData } from '@shared/interfaces';
+import { type BlockData, type BlockCard, type SectionData } from '@shared/interfaces';
 
+const componentContent = [
+`import { Component } from '@angular/core';
+import { MatCard } from '@angular/material/card';
+import { MatIcon } from '@angular/material/icon';
+
+@Component({
+  selector: 'example-features-1',
+  imports: [MatCard, MatIcon],
+  template: \`<section class="py-20 px-4 bg-gray-50 dark:bg-gray-800">
+    <div class="max-w-7xl mx-auto">
+      <div class="text-center mb-16">
+        <h2
+          class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4"
+        >
+          Why Choose Our Components?
+        </h2>
+        <p class="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+          Built with modern best practices and designed for developer
+          productivity
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <mat-card
+          class="p-6 text-center hover:shadow-lg transition-shadow duration-300 animate-slide-up"
+        >
+          <div
+            class="w-16 h-16 bg-primary-100 dark:bg-primary-900 rounded-full flex items-center justify-center mx-auto mb-4"
+          >
+            <mat-icon class="text-3xl">speed</mat-icon>
+          </div>
+          <h3 class="text-xl font-semibold mb-3">Fast Development</h3>
+          <p>
+            Copy and paste components to build your UI in minutes, not hours.
+          </p>
+        </mat-card>
+
+        <mat-card
+          class="p-6 text-center hover:shadow-lg transition-shadow duration-300 animate-slide-up"
+          style="animation-delay: 0.1s;"
+        >
+          <div
+            class="w-16 h-16 bg-green-100 dark:bg-green-900 rounded-full flex items-center justify-center mx-auto mb-4"
+          >
+            <mat-icon class="text-3xl text-green-600 dark:text-green-400"
+              >devices</mat-icon
+            >
+          </div>
+          <h3 class="text-xl font-semibold mb-3 text-gray-900 dark:text-white">
+            Responsive Design
+          </h3>
+          <p class="text-gray-600 dark:text-gray-300">
+            All components are mobile-first and work perfectly on all screen
+            sizes.
+          </p>
+        </mat-card>
+
+        <mat-card
+          class="p-6 text-center hover:shadow-lg transition-shadow duration-300 animate-slide-up"
+          style="animation-delay: 0.2s;"
+        >
+          <div
+            class="w-16 h-16 bg-purple-100 dark:bg-purple-900 rounded-full flex items-center justify-center mx-auto mb-4"
+          >
+            <mat-icon class="text-3xl text-purple-600 dark:text-purple-400"
+              >palette</mat-icon
+            >
+          </div>
+          <h3 class="text-xl font-semibold mb-3 text-gray-900 dark:text-white">
+            Customizable
+          </h3>
+          <p class="text-gray-600 dark:text-gray-300">
+            Easily customize colors, spacing, and styling to match your brand.
+          </p>
+        </mat-card>
+      </div>
+    </div>
+  </section>\`,
+})
+export default class Features1 {}
+`,
+`import { Component } from '@angular/core';
+import { MatCard } from '@angular/material/card';
+import { MatIcon } from '@angular/material/icon';
+
+@Component({
+  selector: 'example-features-2',
+  imports: [MatCard, MatIcon],
+  template: \`
+    <section class="py-20 px-4 bg-white dark:bg-gray-900">
+      <div class="max-w-7xl mx-auto">
+        <div class="text-center mb-16">
+          <h2
+            class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4"
+          >
+            Built for Developers
+          </h2>
+          <p class="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+            Developer-first components for speed, flexibility, and consistency
+          </p>
+        </div>
+
+        <div class="grid gap-10 md:grid-cols-3">
+          <mat-card
+            class="p-6 transition-shadow hover:shadow-xl duration-300 text-left animate-slide-up"
+          >
+            <mat-icon
+              class="text-primary-600 dark:text-primary-400 text-4xl mb-4"
+              >bolt</mat-icon
+            >
+            <h3
+              class="text-xl font-semibold text-gray-900 dark:text-white mb-2"
+            >
+              Performance
+            </h3>
+            <p class="text-gray-600 dark:text-gray-300">
+              Lightweight components optimized for fast loading and smooth
+              interactions.
+            </p>
+          </mat-card>
+
+          <mat-card
+            class="p-6 transition-shadow hover:shadow-xl duration-300 text-left animate-slide-up"
+            style="animation-delay: 0.1s"
+          >
+            <mat-icon class="text-green-600 dark:text-green-400 text-4xl mb-4"
+              >build</mat-icon
+            >
+            <h3
+              class="text-xl font-semibold text-gray-900 dark:text-white mb-2"
+            >
+              Flexible API
+            </h3>
+            <p class="text-gray-600 dark:text-gray-300">
+              Designed to be composable and extendable for advanced use cases.
+            </p>
+          </mat-card>
+
+          <mat-card
+            class="p-6 transition-shadow hover:shadow-xl duration-300 text-left animate-slide-up"
+            style="animation-delay: 0.2s"
+          >
+            <mat-icon class="text-purple-600 dark:text-purple-400 text-4xl mb-4"
+              >verified</mat-icon
+            >
+            <h3
+              class="text-xl font-semibold text-gray-900 dark:text-white mb-2"
+            >
+              Accessibility
+            </h3>
+            <p class="text-gray-600 dark:text-gray-300">
+              Fully accessible out of the box, following the latest WCAG
+              standards.
+            </p>
+          </mat-card>
+        </div>
+      </div>
+    </section>
+  \`,
+})
+export default class Features2 {}
+`,
+`import { Component } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+
+@Component({
+  selector: 'example-features-3',
+  imports: [MatIcon],
+  template: \`
+    <section class="py-20 px-4 bg-gray-100 dark:bg-gray-800">
+      <div class="max-w-6xl mx-auto text-center">
+        <h2
+          class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-10"
+        >
+          How It Works
+        </h2>
+
+        <div class="grid md:grid-cols-3 gap-10">
+          <div class="flex flex-col items-center text-center animate-slide-up">
+            <div
+              class="bg-primary-100 dark:bg-primary-900 w-16 h-16 rounded-full flex items-center justify-center mb-4"
+            >
+              <mat-icon class="text-3xl text-primary-600 dark:text-primary-400"
+                >cloud_download</mat-icon
+              >
+            </div>
+            <h3
+              class="text-xl font-semibold mb-2 text-gray-900 dark:text-white"
+            >
+              Install
+            </h3>
+            <p class="text-gray-600 dark:text-gray-300">
+              Add the package and install all dependencies easily.
+            </p>
+          </div>
+
+          <div
+            class="flex flex-col items-center text-center animate-slide-up"
+            style="animation-delay: 0.1s"
+          >
+            <div
+              class="bg-green-100 dark:bg-green-900 w-16 h-16 rounded-full flex items-center justify-center mb-4"
+            >
+              <mat-icon class="text-3xl text-green-600 dark:text-green-400"
+                >integration_instructions</mat-icon
+              >
+            </div>
+            <h3
+              class="text-xl font-semibold mb-2 text-gray-900 dark:text-white"
+            >
+              Integrate
+            </h3>
+            <p class="text-gray-600 dark:text-gray-300">
+              Use the components in your Angular templates with full Tailwind
+              support.
+            </p>
+          </div>
+
+          <div
+            class="flex flex-col items-center text-center animate-slide-up"
+            style="animation-delay: 0.2s"
+          >
+            <div
+              class="bg-purple-100 dark:bg-purple-900 w-16 h-16 rounded-full flex items-center justify-center mb-4"
+            >
+              <mat-icon class="text-3xl text-purple-600 dark:text-purple-400"
+                >rocket_launch</mat-icon
+              >
+            </div>
+            <h3
+              class="text-xl font-semibold mb-2 text-gray-900 dark:text-white"
+            >
+              Launch
+            </h3>
+            <p class="text-gray-600 dark:text-gray-300">
+              Ship beautiful UIs faster than ever — with confidence.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  \`,
+})
+export default class Features3 {}
+`,
+`import { Component } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+
+@Component({
+  selector: 'example-features-4',
+  imports: [MatIcon],
+  template: \`
+    <section class="py-20 px-4 bg-white dark:bg-gray-900">
+      <div class="max-w-7xl mx-auto">
+        <div class="text-center mb-12">
+          <h2 class="text-3xl font-bold text-gray-900 dark:text-white">
+            Everything You Need
+          </h2>
+        </div>
+
+        <div class="grid sm:grid-cols-2 md:grid-cols-4 gap-8 text-center">
+          <div class="animate-slide-up">
+            <mat-icon
+              class="text-3xl mb-2 text-primary-600 dark:text-primary-400"
+              >code</mat-icon
+            >
+            <h3 class="font-semibold text-gray-900 dark:text-white">
+              Clean Code
+            </h3>
+            <p class="text-sm text-gray-600 dark:text-gray-300">
+              Well-structured and readable.
+            </p>
+          </div>
+          <div class="animate-slide-up" style="animation-delay: 0.1s">
+            <mat-icon class="text-3xl mb-2 text-green-600 dark:text-green-400"
+              >settings</mat-icon
+            >
+            <h3 class="font-semibold text-gray-900 dark:text-white">
+              Configurable
+            </h3>
+            <p class="text-sm text-gray-600 dark:text-gray-300">
+              Options for any project scale.
+            </p>
+          </div>
+          <div class="animate-slide-up" style="animation-delay: 0.2s">
+            <mat-icon class="text-3xl mb-2 text-purple-600 dark:text-purple-400"
+              >grid_view</mat-icon
+            >
+            <h3 class="font-semibold text-gray-900 dark:text-white">
+              Component Library
+            </h3>
+            <p class="text-sm text-gray-600 dark:text-gray-300">
+              Plenty of ready-to-use UI blocks.
+            </p>
+          </div>
+          <div class="animate-slide-up" style="animation-delay: 0.3s">
+            <mat-icon class="text-3xl mb-2 text-yellow-600 dark:text-yellow-400"
+              >support</mat-icon
+            >
+            <h3 class="font-semibold text-gray-900 dark:text-white">
+              Community Support
+            </h3>
+            <p class="text-sm text-gray-600 dark:text-gray-300">
+              Active and growing user base.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  \`,
+})
+export default class Features4 {}
+`,
+];
 // Features Section
 export const featureBlocks: BlockCard[] = [
   {
@@ -40,7 +354,7 @@ export const featuresSectionData: SectionData = {
   blocks: [...featureBlocks],
 };
 
-export const featureBlocksWithViews = featureBlocks.map((block) => {
+export const featureBlocksWithViews: BlockData[] = featureBlocks.map((block, index) => {
   const codeTemplates: any = {
     '1': {
       // Feature Grid
@@ -367,6 +681,7 @@ export class FeatureCarouselComponent {
 
   return {
     ...block,
+    content: componentContent[index],
     views: [
       {
         label: 'Template',
@@ -387,36 +702,3 @@ export class FeatureCarouselComponent {
   };
 });
 
-// Pricing Section
-export const pricingBlocks: BlockCard[] = [
-  {
-    id: '1',
-    title: 'Three-Tier Pricing',
-    description: 'Classic pricing cards with three different plan options',
-    previewUrl: 'https://placehold.co/600x400?text=Three-Tier+Pricing',
-  },
-  {
-    id: '2',
-    title: 'Toggle Pricing',
-    description: 'Monthly/Annual toggle with dynamic price updates',
-    previewUrl: 'https://placehold.co/600x400?text=Toggle+Pricing',
-  },
-  {
-    id: '3',
-    title: 'Enterprise Pricing',
-    description: 'Custom pricing section for enterprise solutions',
-    previewUrl: 'https://placehold.co/600x400?text=Enterprise+Pricing',
-  },
-  {
-    id: '4',
-    title: 'Pricing with Feature Matrix',
-    description: 'Detailed pricing with feature comparison matrix',
-    previewUrl: 'https://placehold.co/600x400?text=Pricing+Matrix',
-  },
-];
-
-export const pricingSectionData = {
-  title: 'UI Pricing Collection',
-  description: 'Convert visitors with clear, attractive pricing sections.',
-  blocks: [...pricingBlocks],
-};

--- a/src/examples/footers/data.ts
+++ b/src/examples/footers/data.ts
@@ -1,4 +1,10 @@
-import { BlockCard, SectionData, BlockData } from '@shared/interfaces';
+import { type BlockData, type BlockCard, type SectionData } from '@shared/interfaces';
+import footer1 from './footer-1.ts?raw';
+import footer2 from './footer-2.ts?raw';
+import footer3 from './footer-3.ts?raw';
+import footer4 from './footer-4.ts?raw';
+
+const componentContent = [footer1, footer2, footer3, footer4];
 
 export const footerBlocks: BlockCard[] = [
   {
@@ -38,7 +44,7 @@ export const footerSectionData: SectionData = {
   blocks: [...footerBlocks],
 };
 
-export const footerBlocksWithViews: BlockData[] = footerBlocks.map((block) => {
+export const footerBlocksWithViews: BlockData[] = footerBlocks.map((block, index) => {
   const codeTemplates: any = {
     '1': {
       template: `<footer class="py-8 bg-gray-100 dark:bg-gray-900">
@@ -158,6 +164,7 @@ export class FooterNavComponent {}`,
 
   return {
     ...block,
+    content: componentContent[index],
     views: [
       {
         label: 'Template',

--- a/src/examples/forms/data.ts
+++ b/src/examples/forms/data.ts
@@ -1,4 +1,10 @@
-import { BlockCard, SectionData, BlockData } from '@shared/interfaces';
+import { type BlockData, type BlockCard, type SectionData } from '@shared/interfaces';
+import forms1 from './forms-1.ts?raw';
+import forms2 from './forms-2.ts?raw';
+import forms3 from './forms-3.ts?raw';
+import forms4 from './forms-4.ts?raw';
+
+const componentContent = [forms1, forms2, forms3, forms4];
 
 export const formsBlocks: BlockCard[] = [
   {
@@ -38,7 +44,7 @@ export const formsSectionData: SectionData = {
   blocks: [...formsBlocks],
 };
 
-export const formsBlocksWithViews: BlockData[] = formsBlocks.map((block) => {
+export const formsBlocksWithViews: BlockData[] = formsBlocks.map((block, index) => {
   const codeTemplates: any = {
     '1': {
       template: `<section class="py-24">
@@ -180,6 +186,7 @@ export class Forms4Component {}`,
 
   return {
     ...block,
+    content: componentContent[index],
     views: [
       {
         label: 'Template',

--- a/src/examples/navigation/data.ts
+++ b/src/examples/navigation/data.ts
@@ -1,4 +1,10 @@
-import { BlockCard, BlockData, SectionData } from '@shared/interfaces';
+import { type BlockCard, type BlockData, type SectionData } from '@shared/interfaces';
+import navigation1 from './navigation-1.ts?raw';
+import navigation2 from './navigation-2.ts?raw';
+import navigation3 from './navigation-3.ts?raw';
+import navigation4 from './navigation-4.ts?raw';
+
+const componentContent = [navigation1, navigation2, navigation3, navigation4];
 
 export const navigationBlocks: BlockCard[] = [
   {
@@ -39,7 +45,7 @@ export const navigationSectionData: SectionData = {
 };
 
 export const navigationBlocksWithViews: BlockData[] = navigationBlocks.map(
-  (block) => {
+  (block, index) => {
     const codeTemplates: any = {
       '1': {
         template: `<mat-toolbar class=\"bg-primary-600 text-white\">
@@ -157,6 +163,7 @@ export class Navigation4Component {}`,
 
     return {
       ...block,
+      content: componentContent[index],
       views: [
         {
           label: 'Template',

--- a/src/examples/pricing/data.ts
+++ b/src/examples/pricing/data.ts
@@ -1,8 +1,14 @@
 import {
   type BlockData,
   type BlockCard,
-  SectionData,
+  type SectionData,
 } from '@shared/interfaces';
+import pricing1 from './pricing-1.ts?raw';
+import pricing2 from './pricing-2.ts?raw';
+import pricing3 from './pricing-3.ts?raw';
+import pricing4 from './pricing-4.ts?raw';
+
+const componentContent = [pricing1, pricing2, pricing3, pricing4];
 
 export const pricingBlocks: BlockCard[] = [
   {
@@ -44,7 +50,7 @@ export const pricingSectionsData: SectionData = {
 };
 
 export const pricingBlocksWithViews: BlockData[] = pricingBlocks.map(
-  (block) => {
+  (block, index) => {
     const codeTemplates: any = {
       '1': {
         template: `<section class="py-20 px-4 bg-gray-50 dark:bg-gray-800">
@@ -357,6 +363,7 @@ export class PricingFlexibleComponent {}`,
 
     return {
       ...block,
+      content: componentContent[index],
       views: [
         {
           label: 'Template',

--- a/src/examples/stats/data.ts
+++ b/src/examples/stats/data.ts
@@ -1,4 +1,10 @@
-import { BlockCard, BlockData, SectionData } from '@shared/interfaces';
+import { type BlockCard, type BlockData, type SectionData } from '@shared/interfaces';
+import stats1 from './stats-1.ts?raw';
+import stats2 from './stats-2.ts?raw';
+import stats3 from './stats-3.ts?raw';
+import stats4 from './stats-4.ts?raw';
+
+const componentContent = [stats1, stats2, stats3, stats4];
 
 export const statsBlocks: BlockCard[] = [
   {
@@ -38,7 +44,7 @@ export const statsSectionData: SectionData = {
   blocks: [...statsBlocks],
 };
 
-export const statsBlocksWithViews: BlockData[] = statsBlocks.map((block) => {
+export const statsBlocksWithViews: BlockData[] = statsBlocks.map((block, index) => {
   const codeTemplates: any = {
     '1': {
       template: `<section class="py-24">
@@ -179,6 +185,7 @@ export class Stats4Component {}`,
 
   return {
     ...block,
+    content: componentContent[index],
     views: [
       {
         label: 'Template',

--- a/src/examples/team/data.ts
+++ b/src/examples/team/data.ts
@@ -1,4 +1,10 @@
-import { type BlockData, type BlockCard } from '@shared/interfaces';
+import { type BlockData, type BlockCard, type SectionData } from '@shared/interfaces';
+import team1 from './team-1.ts?raw';
+import team2 from './team-2.ts?raw';
+import team3 from './team-3.ts?raw';
+import team4 from './team-4.ts?raw';
+
+const componentContent = [team1, team2, team3, team4];
 
 export const teamBlocks: BlockCard[] = [
   {
@@ -41,7 +47,7 @@ export const teamSectionsData = {
 };
 
 // Optional: include code snippets for documentation purposes.
-export const teamBlocksWithViews: BlockData[] = teamBlocks.map((block) => {
+export const teamBlocksWithViews: BlockData[] = teamBlocks.map((block, index) => {
   const codeTemplates: any = {
     '1': {
       template: `<section class="py-24">
@@ -317,6 +323,7 @@ export default class ExampleTeam2Component {
   };
   return {
     ...block,
+    content: componentContent[index],
     views: [
       {
         label: 'Template',

--- a/src/examples/testimonials/data.ts
+++ b/src/examples/testimonials/data.ts
@@ -1,8 +1,14 @@
 import {
   type BlockData,
   type BlockCard,
-  SectionData,
+  type SectionData,
 } from '@shared/interfaces';
+import testimonial1 from './testimonial-1.ts?raw';
+import testimonial2 from './testimonial-2.ts?raw';
+import testimonial3 from './testimonial-3.ts?raw';
+import testimonial4 from './testimonial-4.ts?raw';
+
+const componentContent = [testimonial1, testimonial2, testimonial3, testimonial4];
 
 export const testimonialBlocks: BlockCard[] = [
   {
@@ -46,7 +52,7 @@ export const testimonialSectionsData: SectionData = {
 };
 
 export const testimonialBlocksWithViews: BlockData[] = testimonialBlocks.map(
-  (block) => {
+  (block, index) => {
     const codeTemplates: any = {
       '1': {
         template: `<section class="py-24">
@@ -387,6 +393,7 @@ export class CarouselTestimonialsComponent {
 
     return {
       ...block,
+      content: componentContent[index],
       views: [
         {
           label: 'Template',


### PR DESCRIPTION
## Summary
- expose full component sources for blog, contact, ecommerce, footers, forms, navigation, pricing, stats, team, and testimonial examples
- wire component content into block data views

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68961a8cc8188320a4e82a17dd3bbf00