### PR TITLE
docs: rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,46 @@
-# MaterialBlocks
+# Material Blocks
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.0.5.
+Material Blocks is a collection of reusable UI sections built with **Angular 20**, **Angular Material**, and **Tailwind CSS**. It provides ready‑made building blocks for landing pages, dashboards, and other web apps, with optional server‑side rendering via [AnalogJS](https://analogjs.org).
 
-## Development server
+## Features
+- Prebuilt navigation, hero, pricing, and other content sections under `src/examples/`
+- Angular Material components styled with Tailwind CSS
+- Server‑side rendering support through `@analogjs/platform`
+- Syntax highlighting powered by `highlight.js`
+- Vite development and build tooling
 
-To start a local development server, run:
+## Getting Started
+### Prerequisites
+- Node.js 20+
+- [pnpm](https://pnpm.io) installed globally
 
+### Installation
 ```bash
-ng serve
+pnpm install
 ```
 
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
-
-## Code scaffolding
-
-Angular CLI includes powerful code scaffolding tools. To generate a new component, run:
-
+### Development Server
 ```bash
-ng generate component component-name
+pnpm start
 ```
+Visit <http://localhost:4200> to view the app. The server reloads on file changes.
 
-For a complete list of available schematics (such as `components`, `directives`, or `pipes`), run:
-
+### Build
 ```bash
-ng generate --help
+pnpm build
 ```
+The production build is output to `dist/`.
 
-## Building
-
-To build the project run:
-
+### Testing
 ```bash
-ng build
+pnpm test
 ```
+Runs unit tests with Vitest.
 
-This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
+## Project Structure
+- `src/components/` – shared Angular components
+- `src/examples/` – example page sections
+- `src/server/` – server‑side rendering entry points
 
-## Running unit tests
-
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
-
-```bash
-ng test
-```
-
-## Running end-to-end tests
-
-For end-to-end (e2e) testing, run:
-
-```bash
-ng e2e
-```
-
-Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
-
-## Additional Resources
-
-For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+## License
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- replace Angular CLI starter README with project overview and instructions
- document features, setup, build, test, and project structure

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689627b186b08320a2e000a3421093d3